### PR TITLE
chore(minikube): add local cluster setup scripts and configuration

### DIFF
--- a/infra/minikube/README.md
+++ b/infra/minikube/README.md
@@ -1,0 +1,23 @@
+# 🚀 Minikube Setup
+
+This folder contains all necessary files to initialize a local Kubernetes cluster using Minikube.
+
+## Contents
+
+- `start.sh`: Shell script to start the cluster with predefined settings.
+- `stop.sh`: Script to delete the current cluster.
+- `minikube.env`: Environment variables used by the startup script.
+- `config.yaml`: Reference configuration for Minikube (not automatically loaded).
+
+## Requirements
+
+- Docker
+- Minikube
+- kubectl
+
+## Usage
+
+```bash
+cd infra/minikube
+source minikube.env
+./start.sh

--- a/infra/minikube/config.yaml
+++ b/infra/minikube/config.yaml
@@ -1,0 +1,9 @@
+# Default Minikube cluster configuration (for reference only)
+driver: docker
+cpus: 4
+memory: 8192
+disk-size: "20g"
+kubernetes-version: v1.30.0
+addons:
+  - dashboard
+  - ingress

--- a/infra/minikube/minikube.env
+++ b/infra/minikube/minikube.env
@@ -1,0 +1,7 @@
+# Environment variables for Minikube startup
+
+export MINIKUBE_DRIVER=docker
+export MINIKUBE_CPUS=4
+export MINIKUBE_MEMORY=8192
+export MINIKUBE_K8S_VERSION=v1.30.0
+export MINIKUBE_DISK_SIZE=20g

--- a/infra/minikube/start.sh
+++ b/infra/minikube/start.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Starts the local Minikube cluster using predefined environment variables
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Load environment variables if not already set
+if [ -f "$SCRIPT_DIR/minikube.env" ]; then
+  echo "🔧 Loading environment variables from minikube.env..."
+  source "$SCRIPT_DIR/minikube.env"
+fi
+
+echo "🚀 Starting Minikube with the following configuration:"
+echo "Driver:        ${MINIKUBE_DRIVER}"
+echo "CPUs:          ${MINIKUBE_CPUS}"
+echo "Memory (MB):   ${MINIKUBE_MEMORY}"
+echo "Disk Size:     ${MINIKUBE_DISK_SIZE}"
+echo "K8s Version:   ${MINIKUBE_K8S_VERSION}"
+
+minikube start \
+  --driver="${MINIKUBE_DRIVER}" \
+  --cpus="${MINIKUBE_CPUS}" \
+  --memory="${MINIKUBE_MEMORY}" \
+  --disk-size="${MINIKUBE_DISK_SIZE}" \
+  --kubernetes-version="${MINIKUBE_K8S_VERSION}"
+
+echo "✅ Minikube cluster started successfully."

--- a/infra/minikube/stop.sh
+++ b/infra/minikube/stop.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Stops and deletes the local Minikube cluster
+
+echo "🛑 Stopping and deleting the Minikube cluster..."
+minikube delete
+echo "✅ Minikube cluster deleted."


### PR DESCRIPTION
### 📌 Summary
Add initial scripts and configuration files for setting up a local Minikube Kubernetes cluster using the Docker driver.

### ✅ Changes
List the main changes introduced in this PR:
- Added `start.sh` script to bootstrap Minikube with environment-based parameters  
- Added `stop.sh` script to delete the local Minikube cluster  
- Created `minikube.env` with default values for CPU, memory, disk size, and Kubernetes version  
- Added `config.yaml` as a declarative reference for cluster parameters and suggested addons  
- Added `README.md` with clear setup instructions, usage, and project-specific structure

### 🧪 Testing & Validation
Tested manually on macOS (Apple Silicon) with Docker Desktop:

- Verified that the cluster starts using the environment variables from `minikube.env`
- Confirmed dashboard accessibility and Kubernetes functionality using `kubectl`
- Validated expected behavior after running `start.sh` and `stop.sh`
- Ensured the correct Minikube image was used and that no unused volumes or containers remained after cleanup

### 🔍 Notes
- The current implementation uses `.env` as the active source of truth; `config.yaml` is used for reference only  
- Addons must still be explicitly enabled in `start.sh` (e.g., `ingress`, `dashboard`)  
- Future improvements could include loading `config.yaml` dynamically via `yq` or similar tools 

---

#### Checklist

- [x] Code is functional and runs as expected
- [x] README or other documentation updated (if applicable)
- [x] Commits follow naming convention (e.g., `feat`, `fix`, `docs`, etc.)
