### PR TITLE
fix: use release name for operator rollout

### DIFF
--- a/infra/helm/minio-operator/install-minio-operator.sh
+++ b/infra/helm/minio-operator/install-minio-operator.sh
@@ -10,7 +10,7 @@ helm install "$RELEASE_NAME" minio-operator/operator \
   --create-namespace
 
 echo "⏳ Waiting for MinIO Operator pods to be ready..."
-kubectl rollout status deployment/minio-operator -n "$NAMESPACE"
+kubectl rollout status deployment/"$RELEASE_NAME" -n "$NAMESPACE"
 
 echo "✅ MinIO Operator installed successfully!"
 kubectl get pods -n "$NAMESPACE"


### PR DESCRIPTION
## Summary
- reference the release name when waiting for MinIO Operator rollout

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6896aa8024e883279eb3ddb41bd5130f